### PR TITLE
Support Nim v1.6.x to avoid breaking dependant packages

### DIFF
--- a/hmac.nimble
+++ b/hmac.nimble
@@ -1,6 +1,6 @@
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Huy Doan"
 description   = "HMAC hashing in Nim"
 license       = "MIT"
 
-requires "nim >= 2.0.0", "nimSHA2", "nimcrypto >= 0.5.4"
+requires "nim >= 1.6.10", "nimSHA2", "nimcrypto >= 0.5.4"


### PR DESCRIPTION
@baf03, would it possible to revert this package Nim-requirement?

It still compiles for me with older Nim versions, so I just get breaks from other CI's not updated to Nim 2.0